### PR TITLE
Retain existing headers on reply

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,9 @@ const plugin: FastifyPluginCallback<AuthConfig> = (
     req.raw.body = req.body
     req.raw.query = req.query
     reply.raw.log = req.log
+    for (const [key, val] of Object.entries(reply.getHeaders())) {
+      reply.raw.setHeader(key, val)
+    }
     middie.run(req.raw, reply.raw, next)
   }
 


### PR DESCRIPTION
This change retains existing headers set on the reply in the middleware. This fixes conflicts with other plugins like [fastify-cors](https://github.com/fastify/fastify-cors).